### PR TITLE
feat: Create basic categories support

### DIFF
--- a/content/blog/bolognese/index.md
+++ b/content/blog/bolognese/index.md
@@ -3,7 +3,8 @@ title: Bolognese
 author: Mary Schmidt
 date: "2020-06-06T00:00:00.824Z"
 description: Delicious pasta sauce!
-tags: ["Main", "Pasta"]
+categories: ["Italian", "Meat", "Main", "Flexible", "Favorites"]
+tags: ["Main", "Pasta", "Italian", "Beef", "Flexible", "Tomato", "Lemon"]
 ---
 
 ## Ingredients

--- a/content/blog/brussels-sprouts/index.md
+++ b/content/blog/brussels-sprouts/index.md
@@ -4,7 +4,8 @@ author: Mary Schmidt
 date: "2020-10-30T00:00:00.824Z"
 description: Brussels sprouts were one of those "adult" foods I just never grew into. After what seemed like a requisite number of years following our graduation from college, friends and colleagues began to talk about brussels sprouts being a staple in their weekday diet and it absoultely baffled me. Brussels sprouts? Yep.
 featuredImage: "brussels-sprouts.jpg"
-tags: ["Holiday", "Side"]
+categories: ["Side", "Vegan", "Vegetarian", "Quick"]
+tags: ["Holiday", "Side", "Brussels sprouts", "Lemon"]
 ---
 
 Brussels sprouts were one of those "adult" foods I just never grew into. After what seemed like a requisite number of years following our graduation from college, friends and colleagues began to talk about brussels sprouts being a staple in their weekday diet and it absoultely baffled me. Brussels sprouts? Yep.

--- a/content/blog/cherry-cobbler/index.md
+++ b/content/blog/cherry-cobbler/index.md
@@ -4,7 +4,8 @@ author: Mary Schmidt
 date: "2020-12-03T00:00:00.824Z"
 description: My grandma used to make this dessert all the time as we grew up. Delicious with ice cream or spooned into oatmeal.
 featuredImage: "cherry-cobbler.jpg"
-tags: ["Vegetarian", "Dessert"]
+categories: ["Dessert", "Vegetarian", "Quick"]
+tags: ["Vegetarian", "Dessert", "Cherry", "Blueberry"]
 ---
 
 My grandma used to make this dessert all the time as we grew up. Delicious with ice cream or spooned into oatmeal.

--- a/content/blog/chili/index.md
+++ b/content/blog/chili/index.md
@@ -3,7 +3,8 @@ title: Chili
 author: Mary Schmidt
 date: "2020-10-31T00:00:00.824Z"
 description: What's more personal than a chili recipe? This is my own chili recipe, inspired by my mother's and my time spent in Boston. Hope you enjoy it!
-tags: ["Main", "Meat"]
+categories: ["Main", "Meat", "Flexible", "Favorites"]
+tags: ["Main", "Beef", "Bean", "Chile", "Tomato"]
 ---
 
 What's more personal than a chili recipe? This is my own chili recipe, inspired by my mother's and my time spent in Boston. Hope you enjoy it!

--- a/content/blog/cranberry-sauce/index.md
+++ b/content/blog/cranberry-sauce/index.md
@@ -3,7 +3,8 @@ title: Cranberry Sauce
 author: Mary Schmidt
 date: "2020-01-19T00:00:00.824Z"
 description: The first year I made these, my grandfather told me that in his 90 years of life, cranberries were the one food his family ate every year, even through poverty and the Great Depression. Out of all those cranberries, these were his favorite. I hope you enjoy them as well. 
-tags: ["Holiday", "Side"]
+categories: ["Holiday", "Side", "Favorites"]
+tags: ["Holiday", "Side", "Cranberry", "Orange"]
 ---
 
 The first year I made these, my grandfather told me that in his 90 years of life, cranberries were the one food his family ate every year, even through poverty and the Great Depression. Out of all those cranberries, these were his favorite. I hope you enjoy them as well.

--- a/content/blog/german-potato-salad/index.md
+++ b/content/blog/german-potato-salad/index.md
@@ -5,7 +5,8 @@ date: "2020-05-01T23:49:52.824Z"
 description: Quick, easy, and great with just about everything, from hamburgers to fried pork cutlets. Need I say more? Okay, fine... it's also full of bacon.
 featuredImage: "potato-salad.jpg"
 cta: "Show me the bacon"
-tags: ["Quick", "Bacon", "Side"]
+categories: ["Quick", "Side", "Favorites"]
+tags: ["Quick", "Bacon", "Potato", "Side"]
 ---
 
 Quick, easy, and great with just about everything, from hamburgers to fried pork cutlets. Need I say more? Okay, fine... it's also full of bacon.

--- a/content/blog/mapo-tofu/index.md
+++ b/content/blog/mapo-tofu/index.md
@@ -5,7 +5,8 @@ date: "2020-03-20T02:30:14.478Z"
 description: Joey and I came up with this twist on Mapo Tofu over New Year's and for the months following his visits this was always on my grocery list. It's extremely adaptable — easily made plant based, and pretty much any in-season veggies bring new dimension to the dish.
 featuredImage: "mapo-tofu.jpg"
 cta: Read more
-tags: ["Flexible", "Main", "Rice"]
+categories: ["Chinese", "Main", "Meat", "Flexible", "Favorites"]
+tags: ["Flexible", "Main", "Beef", "Rice"]
 ---
 
 Spicy food lovers, this one's for you.

--- a/content/blog/thai-red-curry/index.md
+++ b/content/blog/thai-red-curry/index.md
@@ -4,7 +4,8 @@ author: Mary Schmidt
 date: "2020-04-30T00:00:00.824Z"
 description: This is a base recipe for a Thai red curry I make almost weekly with whatever's in season. I like to make it with vegetables but you could easily add chicken for more protein. What's presented here is a wintry take on the curry.
 featuredImage: "red-curry.jpg"
-tags: ["Vegan", "Flexible", "Main"]
+categories: ["Thai", "Main", "Vegan", "Vegetarian", "Flexible", "Favorites"]
+tags: ["Vegan", "Flexible", "Main", "Thai", "Squash", "Carrot", "Coconut"]
 ---
 
 This is a base recipe for a Thai red curry I make almost weekly with whatever's in season. I like to make it with vegetables but you could easily add chicken for more protein. What's presented here is a wintry take on the curry.

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "gatsby-transformer-sharp": "^2.5.0",
     "gatsby-transformer-yaml": "^2.4.4",
     "gray-percentage": "^2.0.0",
+    "lodash": "^4.17.20",
     "prismjs": "^1.20.0",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",

--- a/src/components/blog-post.js
+++ b/src/components/blog-post.js
@@ -1,0 +1,76 @@
+import React from "react";
+import Img from "gatsby-image";
+import { Link } from "gatsby";
+
+import { rhythm } from "../utils/typography";
+
+const BlogPost = ({ post }) => {
+    const title = post.frontmatter.title || post.fields.slug;
+    const featuredImgFluid =
+        post.frontmatter.featuredImage?.childImageSharp?.fluid;
+    const tags = post.frontmatter.tags?.join(", ");
+    return (
+        <article
+            key={post.fields.slug}
+            className="card"
+            style={{
+                marginBottom: rhythm(2),
+            }}
+        >
+            <header>
+                {featuredImgFluid && (
+                    <Img
+                        fluid={featuredImgFluid}
+                        style={{
+                            marginTop: rhythm(1 / 2),
+                            marginBottom: rhythm(1 / 2),
+                        }}
+                    />
+                )}
+                <h2
+                    style={{
+                        color: "inherit",
+                        marginTop: rhythm(1),
+                        marginBottom: rhythm(2 / 3),
+                    }}
+                >
+                    <Link style={{ boxShadow: `none` }} to={post.fields.slug}>
+                        {title}
+                    </Link>
+                </h2>
+            </header>
+            <section>
+                <p
+                    dangerouslySetInnerHTML={{
+                        __html: post.frontmatter.description || post.excerpt,
+                    }}
+                />
+                <p>
+                    <Link style={{ boxShadow: `none` }} to={post.fields.slug}>
+                        {(post.frontmatter.cta || "Continue to recipe") + " "}
+                        <span>»</span>
+                    </Link>
+                </p>
+            </section>
+            <footer>
+                <span
+                    style={{
+                        fontSize: "0.9rem",
+                        marginRight: rhythm(1 / 4),
+                    }}
+                >
+                    {post.frontmatter.date}
+                </span>
+                <span
+                    style={{
+                        fontSize: "0.9rem",
+                    }}
+                >
+                    {tags}
+                </span>
+            </footer>
+        </article>
+    );
+};
+
+export default BlogPost;

--- a/src/pages/categories.js
+++ b/src/pages/categories.js
@@ -1,0 +1,72 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+// Utilities
+import kebabCase from "lodash/kebabCase";
+
+// Components
+import { Link, graphql } from "gatsby";
+import Layout from "../components/layout";
+import SEO from "../components/seo";
+
+const CategoriesPage = ({
+    data: {
+        allMarkdownRemark: { group },
+        site: {
+            siteMetadata: { title },
+        },
+    },
+    location
+}) => (
+    <Layout location={location} title={title}>
+        <SEO title="Categories" />       
+        <div>
+            <h1>Categories</h1>
+            <ul>
+                {group.map((category) => (
+                    <li key={category.fieldValue}>
+                        <Link to={`/categories/${kebabCase(category.fieldValue)}/`}>
+                            {category.fieldValue} ({category.totalCount})
+                        </Link>
+                    </li>
+                ))}
+            </ul>
+        </div>
+    </Layout>
+);
+
+CategoriesPage.propTypes = {
+    data: PropTypes.shape({
+        allMarkdownRemark: PropTypes.shape({
+            group: PropTypes.arrayOf(
+                PropTypes.shape({
+                    fieldValue: PropTypes.string.isRequired,
+                    totalCount: PropTypes.number.isRequired,
+                }).isRequired
+            ),
+        }),
+        site: PropTypes.shape({
+            siteMetadata: PropTypes.shape({
+                title: PropTypes.string.isRequired,
+            }),
+        }),
+    }),
+};
+
+export default CategoriesPage;
+
+export const pageQuery = graphql`
+    query {
+        site {
+            siteMetadata {
+                title
+            }
+        }
+        allMarkdownRemark(limit: 2000) {
+            group(field: frontmatter___categories) {
+                fieldValue
+                totalCount
+            }
+        }
+    }
+`;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,10 +1,9 @@
 import React from "react";
-import { Link, graphql } from "gatsby";
-import Img from "gatsby-image";
+import { graphql } from "gatsby";
 
 import Layout from "../components/layout";
 import SEO from "../components/seo";
-import { rhythm } from "../utils/typography";
+import BlogPost from "../components/blog-post";
 
 const BlogIndex = ({ data, location }) => {
     const siteTitle = data.site.siteMetadata.title;
@@ -14,82 +13,7 @@ const BlogIndex = ({ data, location }) => {
         <Layout location={location} title={siteTitle}>
             <SEO title="All posts" />
             {posts.map(({ node }) => {
-                const title = node.frontmatter.title || node.fields.slug;
-                const featuredImgFluid =
-                    node.frontmatter.featuredImage?.childImageSharp?.fluid;
-                const tags = node.frontmatter.tags.join(", ");
-
-                return (
-                    <article
-                        key={node.fields.slug}
-                        className="card"
-                        style={{
-                            marginBottom: rhythm(2),
-                        }}
-                    >
-                        <header>
-                            {featuredImgFluid && (
-                                <Img
-                                    fluid={featuredImgFluid}
-                                    style={{
-                                        marginTop: rhythm(1 / 2),
-                                        marginBottom: rhythm(1 / 2),
-                                    }}
-                                />
-                            )}
-                            <h2
-                                style={{
-                                    color: "inherit",
-                                    marginTop: rhythm(1),
-                                    marginBottom: rhythm(2 / 3),
-                                }}
-                            >
-                                <Link
-                                    style={{ boxShadow: `none` }}
-                                    to={node.fields.slug}
-                                >
-                                    {title}
-                                </Link>
-                            </h2>
-                        </header>
-                        <section>
-                            <p
-                                dangerouslySetInnerHTML={{
-                                    __html:
-                                        node.frontmatter.description ||
-                                        node.excerpt,
-                                }}
-                            />
-                            <p>
-                                <Link
-                                    style={{ boxShadow: `none` }}
-                                    to={node.fields.slug}
-                                >
-                                    {(node.frontmatter.cta ||
-                                        "Continue to recipe") + " "}
-                                    <span>»</span>
-                                </Link>
-                            </p>
-                        </section>
-                        <footer>
-                            <span
-                                style={{
-                                    fontSize: "0.9rem",
-                                    marginRight: rhythm(1 / 4),
-                                }}
-                            >
-                                {node.frontmatter.date}
-                            </span>
-                            <span
-                                style={{
-                                    fontSize: "0.9rem",
-                                }}
-                            >
-                                {tags}
-                            </span>
-                        </footer>
-                    </article>
-                );
+                return <BlogPost post={node} />;
             })}
         </Layout>
     );

--- a/src/templates/categories.js
+++ b/src/templates/categories.js
@@ -1,0 +1,108 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+// Components
+import { Link, graphql } from "gatsby";
+import Layout from "../components/layout";
+import BlogPost from '../components/blog-post'
+import SEO from "../components/seo";
+
+const Categories = ({ pageContext, data, location }) => {
+    const { category } = pageContext;
+    const { edges, totalCount } = data.allMarkdownRemark;
+    const siteTitle = data.site.siteMetadata.title;
+    const tagHeader = `${totalCount} post${
+        totalCount === 1 ? "" : "s"
+    } in ${category} category`;
+
+    return (
+        <Layout location={location} title={siteTitle}>
+            <SEO title="All posts" />
+            <h1>{tagHeader}</h1>
+                {edges.map(({ node }) => {
+                    return (
+                        <BlogPost post={node} />
+                    );
+                })}
+            <Link to="/categories">All categories</Link>
+        </Layout>
+    );
+};
+
+Categories.propTypes = {
+    pageContext: PropTypes.shape({
+        tag: PropTypes.string.isRequired,
+    }),
+    data: PropTypes.shape({
+        allMarkdownRemark: PropTypes.shape({
+            totalCount: PropTypes.number.isRequired,
+            edges: PropTypes.arrayOf(
+                PropTypes.shape({
+                    node: PropTypes.shape({
+                        frontmatter: PropTypes.shape({
+                            title: PropTypes.string.isRequired,
+                        }),
+                        fields: PropTypes.shape({
+                            slug: PropTypes.string.isRequired,
+                        }),
+                    }),
+                }).isRequired
+            ),
+        }),
+        site: PropTypes.shape({
+            siteMetadata: PropTypes.shape({
+                title: PropTypes.string.isRequired,
+            }),
+        }),
+    }),
+};
+
+export default Categories;
+
+export const pageQuery = graphql`
+    query($category: String) {
+        site {
+            siteMetadata {
+                title
+            }
+        }
+        allMarkdownRemark(
+            limit: 2000
+            sort: { fields: [frontmatter___date], order: DESC }
+            filter: { frontmatter: { categories: { in: [$category] } } }
+        ) {
+            totalCount
+            edges {
+                node {
+                    fields {
+                        slug
+                    }
+                    frontmatter {
+                        title
+                        author {
+                            id
+                            summary
+                            photo {
+                                childImageSharp {
+                                    fixed(width: 50, height: 50) {
+                                        ...GatsbyImageSharpFixed
+                                    }
+                                }
+                            }
+                        }
+                        date(formatString: "MMMM DD, YYYY")
+                        description
+                        tags
+                        featuredImage {
+                            childImageSharp {
+                                fluid(maxWidth: 800) {
+                                    ...GatsbyImageSharpFluid
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+`;

--- a/src/templates/categories.js
+++ b/src/templates/categories.js
@@ -11,9 +11,7 @@ const Categories = ({ pageContext, data, location }) => {
     const { category } = pageContext;
     const { edges, totalCount } = data.allMarkdownRemark;
     const siteTitle = data.site.siteMetadata.title;
-    const tagHeader = `${totalCount} post${
-        totalCount === 1 ? "" : "s"
-    } in ${category} category`;
+    const tagHeader = `${category} (${totalCount})`;
 
     return (
         <Layout location={location} title={siteTitle}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -8555,6 +8555,11 @@ lodash@^4.11.1, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.12
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
+lodash@^4.17.20:
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+
 log-update@^3.0.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/log-update/-/log-update-3.4.0.tgz#3b9a71e00ac5b1185cc193a36d654581c48f97b9"


### PR DESCRIPTION
- Add Categories page listing all available categories and how many post are in each
- Add Category specific pages listing posts in the selected category
- ~TODO: Remove Categories page, add to right side of index page instead~

I decided not to remove the Categories page. Instead, let's augment it. Categories will be a listing of each category with ~3 posts from each, and a link to a Category detail page. 

Posts will have a sidebar with 2 prev and 2 next from that category and a link to all categories 